### PR TITLE
Add (opts={}) parameter to initialize definition for custom Prawn::Document

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -61,7 +61,7 @@ application_helper.rb
 
   module ApplicationHelper
     class Foo < Prawn::Document
-      def initialize
+      def initialize(opts={})
         super
         text "Foo"
         text "Bar"


### PR DESCRIPTION
The custom Prawn::Document defined as renderer will be initialized using a single parameter. Reflect that in the README.
