### PR TITLE
Remove Rails3 deprecation warnings

### DIFF
--- a/lib/prawn_rails.rb
+++ b/lib/prawn_rails.rb
@@ -30,7 +30,8 @@ module Prawn
       
     end
     
-    class TemplateHandler < ActionView::Template::Handler
+    class TemplateHandler
+      class_attribute :default_format
       self.default_format = :pdf
       
       def self.call(template)


### PR DESCRIPTION
As also mentioned by @tankwanghow in issue #6, prawn-rails touches on some deprecated code which produces some warnings.

I made a small change to Prawn::Rails::TemplateHandler fixing this issue. It works fine with Rails3.1, but I haven't tested this in Rails 3.0 yet - all though judging from how the Rails 3.0.9 template handlers in the Rails core look, it should be fine.
