### PR TITLE
This patch makes rendering of partials possible

### DIFF
--- a/lib/prawn_rails.rb
+++ b/lib/prawn_rails.rb
@@ -7,39 +7,39 @@ end
 
 module Prawn
   module Rails
-    
+
     module PrawnHelper
-      
+
       def prawn_document(opts={})
         download = opts.delete(:force_download)
         filename = opts.delete(:filename)
         pdf = (opts.delete(:renderer) || Prawn::Document).new(opts)
         yield pdf if block_given?
-        
+
         disposition(download, filename) if (download || filename)
-        
-        pdf
+
+        pdf.render
       end
-      
+
       def disposition(download, filename)
         download = true if (filename && download == nil)
         disposition = download ? "attachment;" : "inline;"
         disposition += " filename=\"#{filename}\"" if filename
         headers["Content-Disposition"] = disposition
       end
-      
+
     end
-    
+
     class TemplateHandler
       class_attribute :default_format
       self.default_format = :pdf
-      
+
       def self.call(template)
-        "#{template.source.strip}.render"        
+        "#{template.source.strip}"
       end
-      
+
     end
-    
+
   end
 end
 


### PR DESCRIPTION
Hi Volundr,

I've moved the call to `#render` from the handler to the helper, this makes rendering partials possible. Like this:

```
    prawn_document do |pdf|
      render "frontpage", :pdf => pdf
      text "something else"
    end
```

This now renders a file `_frontpage.pdf.prawn`. This fails in the current version.

Roel
