### PR TITLE
Prevent warning about redefinition of Mime::Type

### DIFF
--- a/lib/prawn_rails.rb
+++ b/lib/prawn_rails.rb
@@ -43,6 +43,6 @@ module Prawn
   end
 end
 
-Mime::Type.register_alias "application/pdf", :pdf
+Mime::Type.register_alias("application/pdf", :pdf) unless Mime::Type.lookup_by_extension(:pdf)
 ActionView::Template.register_template_handler(:prawn, Prawn::Rails::TemplateHandler)
 ActionView::Base.send(:include, Prawn::Rails::PrawnHelper)


### PR DESCRIPTION
My app seems to complain about PDF being predefined somewhere already.

``` ruby
    ...actionpack-3.2.0.rc1/lib/action_dispatch/http/mime_type.rb:101: warning: already initialized constant PDF
```

It may be prudent to check before registering alias.
