### PR TITLE
Depend on railties instead of rails

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ Jeweler::Tasks.new do |gem|
   gem.has_rdoc = false
   gem.extra_rdoc_files = ["README.rdoc"]
   gem.license = "MIT"
-  gem.add_dependency('rails', '>=3.0.0')
+  gem.add_dependency('railties', '>=3.0.0')
   gem.add_dependency('prawn', '>=0.11.1')
 end
 Jeweler::RubygemsDotOrgTasks.new

--- a/prawn_rails.gemspec
+++ b/prawn_rails.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Walton Hoops"]
-  s.date = "2012-08-21"
+  s.date = "2012-08-28"
   s.description = "The prawn_rails gem provides a Prawn based view engine for creating PDFs with rails."
   s.email = "me@waltonhoops.com"
   s.extra_rdoc_files = [
@@ -28,21 +28,21 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/Whoops/prawn-rails"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = "1.8.24"
+  s.rubygems_version = "1.8.11"
   s.summary = "Integrates Prawn into Rails in a natural way"
 
   if s.respond_to? :specification_version then
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rails>, [">= 3.0.0"])
+      s.add_runtime_dependency(%q<railties>, [">= 3.0.0"])
       s.add_runtime_dependency(%q<prawn>, [">= 0.11.1"])
     else
-      s.add_dependency(%q<rails>, [">= 3.0.0"])
+      s.add_dependency(%q<railties>, [">= 3.0.0"])
       s.add_dependency(%q<prawn>, [">= 0.11.1"])
     end
   else
-    s.add_dependency(%q<rails>, [">= 3.0.0"])
+    s.add_dependency(%q<railties>, [">= 3.0.0"])
     s.add_dependency(%q<prawn>, [">= 0.11.1"])
   end
 end


### PR DESCRIPTION
This avoids pulling dependencies into an app that it might not need, for example activerecord.
