### PR TITLE
Fix deprecation warning for template handlers

### DIFF
--- a/lib/prawn_rails.rb
+++ b/lib/prawn_rails.rb
@@ -34,8 +34,8 @@ module Prawn
       class_attribute :default_format
       self.default_format = :pdf
 
-      def self.call(template)
-        "#{template.source.strip}"
+      def self.call(_template, source)
+        source.strip.to_s
       end
 
     end


### PR DESCRIPTION
This PR fixes a deprecation warning introduced by changes in Rails 6. This updates the gem for use with Rails 6.

DEPRECATION WARNING: Single arity template handlers are deprecated. Template handlers must now accept two parameters, the view object and the source for the view object.