### PR TITLE
Fixes deprecation warning when used with Rails 6

### DIFF
--- a/lib/prawn_rails.rb
+++ b/lib/prawn_rails.rb
@@ -34,8 +34,12 @@ module Prawn
       class_attribute :default_format
       self.default_format = :pdf
 
-      def self.call(template)
-        "#{template.source.strip}"
+      def self.call(template, source = nil)
+        if source
+          "#{source.strip}"
+        else
+          "#{template.source.strip}"
+        end
       end
 
     end


### PR DESCRIPTION
This commit adds an optional second parameter source, which if not provided falls back to nil, making it compatible with older versions of Rails.

Here's the warning that shows up if you use this gem with Rails 6:

DEPRECATION WARNING: Single arity template handlers are deprecated. Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> Prawn::Rails::TemplateHandler.call(template)
To:
  >> Prawn::Rails::TemplateHandler.call(template, source)